### PR TITLE
Added missing HasPrevious assignment in page conversion method.

### DIFF
--- a/src/RSql4Net/Models/Paging/RSqlPage.cs
+++ b/src/RSql4Net/Models/Paging/RSqlPage.cs
@@ -117,6 +117,7 @@ namespace RSql4Net.Models.Paging
                 Content = Content.Select(selector).ToList(),
                 HasContent = HasContent,
                 HasNext = HasNext,
+                HasPrevious = HasPrevious,
                 TotalElements = TotalElements,
                 TotalPages = TotalPages,
                 NumberOfElements = NumberOfElements


### PR DESCRIPTION
The 'As' conversion method in the RSqlPage Model was missing the HasPrevious assignment, and that value was being lost when using the method.